### PR TITLE
Fix/chat summary

### DIFF
--- a/src/background.ts
+++ b/src/background.ts
@@ -58,28 +58,9 @@ chrome.runtime.onMessage.addListener(async (message, sender, sendResponse) => {
     await chrome.sidePanel.open({ tabId });
 
     store.dispatch(openSidePanel());
-    await store.dispatch(summarizeChatHistory({ currentTabId: tabId }));
-
     sendResponse({ status: "success", isOpen: true });
-  } else if (message.action === "summarizeText") {
-    const summary = await new Promise<string>((resolve, reject) => {
-      chrome.tabs.sendMessage(
-        tabId,
-        { action: "summarizeText", text: message.text },
-        (response) => {
-          if (chrome.runtime.lastError) {
-            reject(new Error(chrome.runtime.lastError.message));
-          } else if (response.error) {
-            reject(new Error(response.error));
-          } else {
-            console.log("Summary received:", response.summary);
-            resolve(response.summary);
-          }
-        }
-      );
-    });
 
-    sendResponse({ status: "success", summary });
+    await store.dispatch(summarizeChatHistory());
   } else if (message.action === "closeSidePanel") {
     chrome.sidePanel.setOptions({
       tabId,

--- a/src/background.ts
+++ b/src/background.ts
@@ -58,9 +58,31 @@ chrome.runtime.onMessage.addListener(async (message, sender, sendResponse) => {
     await chrome.sidePanel.open({ tabId });
 
     store.dispatch(openSidePanel());
-    sendResponse({ status: "success", isOpen: true });
+    const summarizeResult = await store.dispatch(
+      summarizeChatHistory({ currentTabId: tabId })
+    );
+    console.log("summarizeChatHistory result:", summarizeResult);
 
-    await store.dispatch(summarizeChatHistory());
+    sendResponse({ status: "success", isOpen: true });
+  } else if (message.action === "summarizeText") {
+    const summary = await new Promise<string>((resolve, reject) => {
+      chrome.tabs.sendMessage(
+        tabId,
+        { action: "summarizeText", text: message.text },
+        (response) => {
+          if (chrome.runtime.lastError) {
+            reject(new Error(chrome.runtime.lastError.message));
+          } else if (response.error) {
+            reject(new Error(response.error));
+          } else {
+            console.log("Summary received:", response.summary);
+            resolve(response.summary);
+          }
+        }
+      );
+    });
+
+    sendResponse({ status: "success", summary });
   } else if (message.action === "closeSidePanel") {
     chrome.sidePanel.setOptions({
       tabId,
@@ -117,3 +139,130 @@ chrome.runtime.onInstalled.addListener(() => {
 });
 
 export {};
+
+/*DEV_NOTE : this below part is works more clean about the used summarize text in the slice 
+instead of fetchGeminiSummarizer usage but somehow ai summarize wants us to use background
+messaging system in order to works immeadiately as sidepanel opens. 
+
+while Content summary working flawlesly we get error triggered summarize chat session logic 
+*/
+
+// import { configureStore } from "@reduxjs/toolkit";
+// import rootReducer from "./redux/rootReducer";
+// import { createWrapStore } from "webext-redux";
+// import { setActiveTab } from "./redux/slices/uiSlice";
+// import {
+//   closeSidePanel,
+//   openSidePanel,
+//   saveChatHistory,
+//   summarizeChatHistory,
+// } from "./redux/slices/sidePanelSlice";
+
+// const store = configureStore({
+//   reducer: rootReducer,
+// });
+// const wrapStore = createWrapStore();
+// wrapStore(store);
+
+// // Track the current active tab ID
+// let currentTabId: number | null = null;
+
+// chrome.tabs.onActivated.addListener((activeInfo) => {
+//   chrome.tabs.get(activeInfo.tabId, (tab) => {
+//     if (chrome.runtime.lastError) {
+//       return;
+//     }
+//     currentTabId = tab.id || null;
+//   });
+// });
+
+// chrome.tabs.onUpdated.addListener((tabId, changeInfo, tab) => {
+//   if (tab.active && changeInfo.url) {
+//     currentTabId = tabId;
+//   }
+// });
+
+// /////////////////////// OPEN CLOSE sidepanel ///////////////////////
+// chrome.tabs.onUpdated.addListener((tabId, changeInfo, tab) => {
+//   if (tab.active && changeInfo.url) {
+//     currentTabId = tabId;
+//   }
+// });
+
+// chrome.runtime.onMessage.addListener(async (message, sender, sendResponse) => {
+//   const tabId = currentTabId || message.tabId || sender.tab?.id;
+
+//   if (!tabId) {
+//     sendResponse({ status: "error", message: "No active tab available." });
+//     return true;
+//   }
+
+//   if (message.action === "openSidePanel") {
+//     chrome.sidePanel.setOptions({
+//       tabId,
+//       path: "sidepanel.html",
+//       enabled: true,
+//     });
+
+//     await chrome.sidePanel.open({ tabId });
+
+//     store.dispatch(openSidePanel());
+//     sendResponse({ status: "success", isOpen: true });
+
+//     await store.dispatch(summarizeChatHistory());
+//   } else if (message.action === "closeSidePanel") {
+//     chrome.sidePanel.setOptions({
+//       tabId,
+//       enabled: false,
+//     });
+
+//     store.dispatch(saveChatHistory());
+//     store.dispatch(closeSidePanel());
+//     sendResponse({ status: "success", isOpen: false });
+//   }
+
+//   return true;
+// });
+
+// //SAVING CHAT DATA
+// // Listen for extension unload (popup or browser close)
+// chrome.runtime.onSuspend.addListener(() => {
+//   store.dispatch(saveChatHistory());
+// });
+
+// // Listen for window closure
+// chrome.windows.onRemoved.addListener(() => {
+//   store.dispatch(saveChatHistory());
+// });
+
+// // Listen for tab closure
+// chrome.tabs.onRemoved.addListener(() => {
+//   store.dispatch(saveChatHistory());
+// });
+
+// // Track the current active Component
+// const validComponents = ["ChatBox", "Content", "Interest"];
+
+// chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
+//   if (message.type === "SET_ACTIVE_TAB") {
+//     const requestedTab = message.payload;
+
+//     if (validComponents.includes(requestedTab)) {
+//       store.dispatch(setActiveTab(requestedTab));
+//       sendResponse({ status: "success", activeTab: requestedTab });
+//     } else {
+//       sendResponse({ status: "error", message: "Invalid component name" });
+//     }
+//   } else if (message.type === "GET_ACTIVE_TAB") {
+//     const state = store.getState();
+//     sendResponse({ activeTab: state.ui.activeTab });
+//   }
+//   return true;
+// });
+
+// // Set the extension icon
+// chrome.runtime.onInstalled.addListener(() => {
+//   chrome.action.setIcon({ path: "src/assets/icons/icon400.png" });
+// });
+
+// export {};

--- a/src/background.ts
+++ b/src/background.ts
@@ -4,7 +4,6 @@ import { createWrapStore } from "webext-redux";
 import { setActiveTab } from "./redux/slices/uiSlice";
 import {
   closeSidePanel,
-  openSidePanel,
   saveChatHistory,
   summarizeChatHistory,
 } from "./redux/slices/sidePanelSlice";
@@ -57,7 +56,6 @@ chrome.runtime.onMessage.addListener(async (message, sender, sendResponse) => {
 
     await chrome.sidePanel.open({ tabId });
 
-    store.dispatch(openSidePanel());
     const summarizeResult = await store.dispatch(
       summarizeChatHistory({ currentTabId: tabId })
     );

--- a/src/redux/slices/sidePanelSlice.ts
+++ b/src/redux/slices/sidePanelSlice.ts
@@ -1,8 +1,8 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import { createAsyncThunk, createSlice, PayloadAction } from "@reduxjs/toolkit";
 
-import { saveSessionData } from "../../utils/dataUtils";
-import { processChatHistory } from "../../utils/fetchGeminiSummarize";
+import { saveSessionData, saveSummaryData } from "../../utils/dataUtils";
+// import { processChatHistory } from "../../utils/fetchGeminiSummarize";
 
 export interface SidePanelState {
   isOpen: boolean;
@@ -26,21 +26,77 @@ export const saveChatHistory = createAsyncThunk(
   }
 );
 
+// !!!!!!!  DEV_NOTE : this version works because it triggered with the background messaging system, Above one responds browser not support kinda message
 export const summarizeChatHistory = createAsyncThunk(
   "sidePanel/summarizeChatHistory",
-  async (_, { getState }) => {
+  async ({ currentTabId }: { currentTabId: number }, { getState }) => {
     const state: { sidePanel: SidePanelState } = getState() as any;
 
     if (!state.sidePanel.isOpen) {
-      console.log(
-        "[summarizeChatHistory] - Side panel is not open. Skipping chat summary."
-      );
       return;
     }
 
-    await processChatHistory();
+    const { chatHistory } = await new Promise<{
+      chatHistory: Array<{ sender: string; text: string }>;
+    }>((resolve) =>
+      chrome.storage.local.get("chatHistory", (data) => {
+        resolve({ chatHistory: data.chatHistory || [] });
+      })
+    );
+
+    //checking chatHistory with lenght because it may null or
+    if (chatHistory.length > 0) {
+      const fullChatText = chatHistory.map((entry) => entry.text).join(" ");
+      console.log("Full chat text for summary:", fullChatText);
+
+      try {
+        const summary = await new Promise<string>((resolve, reject) => {
+          chrome.tabs.sendMessage(
+            currentTabId,
+            { action: "summarizeText", text: fullChatText },
+            (response) => {
+              if (chrome.runtime.lastError) {
+                reject(new Error(chrome.runtime.lastError.message));
+              } else if (response.error) {
+                reject(new Error(response.error));
+              } else {
+                resolve(response.summary);
+              }
+            }
+          );
+        });
+
+        saveSummaryData(summary);
+        console.log("summary:", summary);
+
+        return summary;
+      } catch (error) {
+        console.error("Error summarizing text:", error);
+        return "Unable to summarize at this time.";
+      }
+    } else {
+      console.log("No chat history found. Skipping summarization.");
+    }
   }
 );
+
+//TODO make it more simpler and cleaner with messaging system like above !
+
+// export const summarizeChatHistory = createAsyncThunk(
+//   "sidePanel/summarizeChatHistory",
+//   async (_, { getState }) => {
+//     const state: { sidePanel: SidePanelState } = getState() as any;
+
+//     if (!state.sidePanel.isOpen) {
+//       console.log(
+//         "[summarizeChatHistory] - Side panel is not open. Skipping chat summary."
+//       );
+//       return;
+//     }
+
+//     await processChatHistory();
+//   }
+// );
 
 const sidePanelSlice = createSlice({
   name: "sidePanel",

--- a/src/types/componentType.ts
+++ b/src/types/componentType.ts
@@ -1,1 +1,5 @@
-export type ComponentType = "chatbox" | "interest" | "content" | "summarize";
+export type ComponentType =
+  | "chatbox"
+  | "interest"
+  | "content"
+  | "summarizeChat";

--- a/src/utils/config/promptConfig.ts
+++ b/src/utils/config/promptConfig.ts
@@ -25,8 +25,7 @@ export const promptConfig: Record<
 > = {
   chatbox: {
     promptTemplate: `You are a helpful assistant. User message: "{userMessage}". Limit response to 100 words.`,
-    continuedPromptTemplate: `You are a helpful assistant. Summary so far: "{summaryData}". User message: "{userMessage}". Limit response to 100 words.`,
-    defaultPromptTemplate: `Continue to chat with the user with a helpful attitude: "{userMessage}". Limit response to 100 words.`,
+    continuedPromptTemplate: `Based on this data "{summaryData}" respond "{userMessage}". Limit response to 100 words.`,
     saveData: saveChatData,
   },
   interest: {

--- a/src/utils/config/promptConfig.ts
+++ b/src/utils/config/promptConfig.ts
@@ -11,7 +11,7 @@ type SaveDataFunction = {
   chatbox: (data: Message) => void;
   interest: (data: string[]) => void;
   content: (data: string[]) => void;
-  summarize: (data: string) => void;
+  summarizeChat: (data: string) => void;
 };
 
 export const promptConfig: Record<
@@ -38,7 +38,7 @@ export const promptConfig: Record<
     promptTemplate: `Generate a one-sentence joke about this title: "{userMessage}"`,
     saveData: saveContentData,
   },
-  summarize: {
+  summarizeChat: {
     promptTemplate: `Summarize the following conversation data in concise points: "{sessionData}" limit your response to 50 words`,
     saveData: saveSummaryData,
   },

--- a/src/utils/fetchGeminiSummarize.tsx
+++ b/src/utils/fetchGeminiSummarize.tsx
@@ -1,21 +1,35 @@
-import { loadHistoryData, saveInterestData } from "./dataUtils";
+import {
+  loadHistoryData,
+  loadSessionData,
+  saveInterestData,
+  saveSummaryData,
+} from "./dataUtils";
 import { promptConfig } from "../utils/config/promptConfig";
 import { handleError } from "./error/errorHandler";
+import { Message } from "../types/messageType";
 
 export const summarizeText = async (text: string): Promise<string> => {
   if (typeof window === "undefined" || !window.ai || !window.ai.summarizer) {
-    throw new Error("AI Summarization is not supported in this browser.");
+    console.warn(
+      "[summarizeText] - AI Summarization not available. Using fallback."
+    );
+    return "Summarization is currently unavailable. Please try again later.";
   }
 
-  const session = await window.ai.summarizer.create({
-    type: "key-points",
-    format: "plain-text",
-    length: "short",
-  });
+  try {
+    const session = await window.ai.summarizer.create({
+      type: "key-points",
+      format: "plain-text",
+      length: "short",
+    });
 
-  const summary = await session.summarize(text);
-  session.destroy();
-  return summary;
+    const summary = await session.summarize(text);
+    session.destroy();
+    return summary;
+  } catch (error) {
+    console.error("[summarizeText] - Error during summarization:", error);
+    return "An error occurred while summarizing the text.";
+  }
 };
 
 export const processSummarizedHistory = async (): Promise<void> => {
@@ -62,4 +76,45 @@ export const processSummarizedHistory = async (): Promise<void> => {
       );
     }
   });
+};
+
+// process for maintaining the chat continuity
+export const processChatHistory = async (): Promise<string | null> => {
+  const sessionData = await new Promise<Message[]>((resolve) =>
+    loadSessionData((data) => resolve(data || []))
+  );
+
+  if (!sessionData.length) {
+    console.log(
+      "[summarizeChatHistory3] - No sessionData found. Skipping summarization."
+    );
+    return null;
+  }
+
+  const formattedSessionData = sessionData
+    .map((entry) => `${entry.sender}: ${entry.text}`)
+    .join(" ");
+
+  console.log(
+    "[summarizeChatHistory3] - Formatted session data:",
+    formattedSessionData
+  );
+
+  const { promptTemplate } = promptConfig.summarize;
+  const prompt = promptTemplate.replace("{sessionData}", formattedSessionData);
+
+  console.log("[summarizeChatHistory3] - Generated prompt for AI:", prompt);
+
+  try {
+    const summary = await summarizeText(prompt);
+    console.log("[summarizeChatHistory3] - AI-generated summary:", summary);
+
+    saveSummaryData(summary);
+    console.log("[summarizeChatHistory3] - Summary saved:", summary);
+
+    return summary;
+  } catch (error) {
+    console.error("[summarizeChatHistory3] - Error summarizing text:", error);
+    return "Unable to summarize at this time.";
+  }
 };

--- a/src/utils/fetchGeminiSummarize.tsx
+++ b/src/utils/fetchGeminiSummarize.tsx
@@ -1,12 +1,6 @@
-import {
-  loadHistoryData,
-  loadSessionData,
-  saveInterestData,
-  saveSummaryData,
-} from "./dataUtils";
+import { loadHistoryData, saveInterestData } from "./dataUtils";
 import { promptConfig } from "../utils/config/promptConfig";
 import { handleError } from "./error/errorHandler";
-import { Message } from "../types/messageType";
 
 export const summarizeText = async (text: string): Promise<string> => {
   if (typeof window === "undefined" || !window.ai || !window.ai.summarizer) {
@@ -40,7 +34,7 @@ export const processSummarizedHistory = async (): Promise<void> => {
     }
 
     try {
-      const { promptTemplate } = promptConfig["summarize"];
+      const { promptTemplate } = promptConfig["interest"];
 
       const summaryPromises = historyItems.map(async (item) => {
         try {
@@ -79,66 +73,66 @@ export const processSummarizedHistory = async (): Promise<void> => {
 };
 
 // process for maintaining the chat continuity
-export const processChatHistory = async (): Promise<string | null | undefined> => {
-  const sessionData = await new Promise<Message[]>((resolve) =>
-    loadSessionData((data) => resolve(data || []))
-  );
+// export const processChatHistory = async (): Promise<string | null | undefined> => {
+//   const sessionData = await new Promise<Message[]>((resolve) =>
+//     loadSessionData((data) => resolve(data || []))
+//   );
 
-  if (!sessionData.length) {
-    console.log(
-      "[fetchGeminiSummarize-processChatHistory] - No sessionData found. Skipping summarization."
-    );
-    return null;
-  }
+//   if (!sessionData.length) {
+//     console.log(
+//       "[fetchGeminiSummarize-processChatHistory] - No sessionData found. Skipping summarization."
+//     );
+//     return null;
+//   }
 
-  const formattedSessionData = sessionData
-    .map((entry) => `${entry.sender}: ${entry.text}`)
-    .join(" ");
+//   const formattedSessionData = sessionData
+//     .map((entry) => `${entry.sender}: ${entry.text}`)
+//     .join(" ");
 
-  console.log(
-    "[fetchGeminiSummarize-processChatHistory] - Formatted session data:",
-    formattedSessionData
-  );
+//   console.log(
+//     "[fetchGeminiSummarize-processChatHistory] - Formatted session data:",
+//     formattedSessionData
+//   );
 
-  // Check Summarizer API availability
-  const canSummarize = await self.ai.summarizer.capabilities();
-  if (!canSummarize || canSummarize.available === "no") {
-    console.log("[processChatHistory] - Summarizer API is not available.");
-    return "Summarization is currently unavailable.";
-  }
+//   // Check Summarizer API availability
+//   const canSummarize = await self.ai.summarizer.capabilities();
+//   if (!canSummarize || canSummarize.available === "no") {
+//     console.log("[processChatHistory] - Summarizer API is not available.");
+//     return "Summarization is currently unavailable.";
+//   }
 
-  if (canSummarize.available === "readily") {
-    const { promptTemplate } = promptConfig.summarize;
-    const prompt = promptTemplate.replace(
-      "{sessionData}",
-      formattedSessionData
-    );
+//   if (canSummarize.available === "readily") {
+//     const { promptTemplate } = promptConfig.summarize;
+//     const prompt = promptTemplate.replace(
+//       "{sessionData}",
+//       formattedSessionData
+//     );
 
-    console.log(
-      "[fetchGeminiSummarize-processChatHistory] - Generated prompt for AI:",
-      prompt
-    );
+//     console.log(
+//       "[fetchGeminiSummarize-processChatHistory] - Generated prompt for AI:",
+//       prompt
+//     );
 
-    try {
-      const summary = await summarizeText(prompt);
-      console.log(
-        "[fetchGeminiSummarize-processChatHistory] - AI-generated summary:",
-        summary
-      );
+//     try {
+//       const summary = await summarizeText(prompt);
+//       console.log(
+//         "[fetchGeminiSummarize-processChatHistory] - AI-generated summary:",
+//         summary
+//       );
 
-      saveSummaryData(summary);
-      console.log(
-        "[fetchGeminiSummarize-processChatHistory] - Summary saved:",
-        summary
-      );
+//       saveSummaryData(summary);
+//       console.log(
+//         "[fetchGeminiSummarize-processChatHistory] - Summary saved:",
+//         summary
+//       );
 
-      return summary;
-    } catch (error) {
-      console.error(
-        "[fetchGeminiSummarize-processChatHistory] - Error summarizing text:",
-        error
-      );
-      return "Unable to summarize at this time.";
-    }
-  }
-};
+//       return summary;
+//     } catch (error) {
+//       console.error(
+//         "[fetchGeminiSummarize-processChatHistory] - Error summarizing text:",
+//         error
+//       );
+//       return "Unable to summarize at this time.";
+//     }
+//   }
+// };


### PR DESCRIPTION
expected flow
- [x] Open sidePanel:  trigger >> summarization chat data . (If session data exist)        -{!sessionData}  skip summary && continue to default prompt 
- [x] Close Side Panel : trigger >> save chat history to session Data 
- [x] Re Open SidePanel : trigger Summarization chat data into summary         -{sessionData} so generate summary  select Continue Prompt to chat  
- [x] user send msg : delete session data && summary so back to initial Prompt !  so it back to initial prompt logic 

tested 👌 
